### PR TITLE
Fix Furniture app repository link and image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A Collection of Flutter Material User Interfaces
 <img src="https://github.com/Safnaj/Flutter-UI-Samples/blob/master/Leather_Shop/assets/Leather_UI.jpg" width="480" height="480"/>
 </div>
 
-## [3. Furniture_App](https://github.com/adityathakurxd/Flutter-UI-Samples/tree/master/Furniture_App)
+## [3. Furniture_App](https://github.com/Safnaj/Flutter-UI-Samples/tree/master/Furniture_App)
 <div>
-<img src="https://github.com/adityathakurxd/Flutter-UI-Samples/blob/master/Furniture_App/Furniture_App.png" width="480" height="480"/>
+<img src="https://github.com/Safnaj/Flutter-UI-Samples/blob/master/Furniture_App/Furniture_App.png" width="480" height="480"/>
 </div>
 
 ## [4. Onboarding_App](https://github.com/hiashutoshsingh/Flutter-UI-Samples/tree/master/Onboarding_App)


### PR DESCRIPTION
In this PR, I fixed the image and repository link in the `README`.